### PR TITLE
added encoding marker for Pod

### DIFF
--- a/lib/Bash/Completion/Plugins/VimTag.pm
+++ b/lib/Bash/Completion/Plugins/VimTag.pm
@@ -49,6 +49,11 @@ sub complete {
 }
 1;
 
+__END__
+=pod
+
+=encoding UTF-8
+
 =head1 NAME
 
 Bash::Completion::Plugins::VimTag - Bash completion plugin for vim tags


### PR DESCRIPTION
This should remove "POD Error" warning on [MetaCPAN page](https://metacpan.org/pod/Bash::Completion::Plugins::VimTag).

On a related note, I wasn't able to find GitHub-based home for `Vim::Tag`. [Previous address](https://github.com/hanekomu/Vim-Tag) gives 404 right now.